### PR TITLE
Arguments sorted to avoid migration error

### DIFF
--- a/zp_picturefill.php
+++ b/zp_picturefill.php
@@ -637,7 +637,7 @@ function getHDDefaultSizedImage($imgobj = null, $hd = true) {
  * @param string $class Optional style class
  * @param string $id Optional style id
  */
-function printHDDefaultSizedImage($imgobj = null, $hd = true, $alt = null, $class = null, $id = null) {
+function printHDDefaultSizedImage($alt = null, $class = null, $id = null, $imgobj = null, $hd = true) {
 	global $_zp_current_image;
   if (is_null($imgobj)) {
     $imgobj = $_zp_current_image;

--- a/zp_picturefill.php
+++ b/zp_picturefill.php
@@ -719,7 +719,7 @@ function printHDImageThumb($alt = null, $class = null, $id = null, $imgobj = nul
  * @param string $id optional id tag
  * @param string $albobj Album object optionally
  */
-function printHDAlbumThumbImage($hd = true, $alt = null, $class = null, $id = null, $albobj = null) {
+function printHDAlbumThumbImage($alt = null, $class = null, $id = null, $albobj = null, $hd = true) {
 	global $_zp_current_album;
 	if(is_null($albobj)) {
 		$imgobj = $_zp_current_album->getAlbumThumbImage();
@@ -763,7 +763,7 @@ function printHDAlbumThumbImage($hd = true, $alt = null, $class = null, $id = nu
  *
  * @return string
  */
-function printHDCustomAlbumThumbImage($hd = true, $alt = null, $size, $width = null, $height = null, $cropw = null, $croph = null, $cropx = null, $cropy = null, $class = null, $id = null, $albobj = null) {
+function printHDCustomAlbumThumbImage($alt = null, $size, $width = null, $height = null, $cropw = null, $croph = null, $cropx = null, $cropy = null, $class = null, $id = null, $albobj = null, $hd = true) {
 	global $_zp_current_album;
 	if(is_null($albobj)) {
 		$imgobj = $_zp_current_album->getAlbumThumbImage();

--- a/zp_picturefill.php
+++ b/zp_picturefill.php
@@ -631,11 +631,11 @@ function getHDDefaultSizedImage($imgobj = null, $hd = true) {
  * Standard sized image with normal and HiDPI resolution as set on the options
  * Note: Does not work with  non image files like video or audio. Exclude them on your the theme!
  *
- * @param obj $imgobj Image object If NULL the current image is used
- * @param bool $hd Set to true if the HiDPI counterpart should be generated
  * @param string $alt Alt text
  * @param string $class Optional style class
  * @param string $id Optional style id
+ * @param obj $imgobj Image object If NULL the current image is used
+ * @param bool $hd Set to true if the HiDPI counterpart should be generated
  */
 function printHDDefaultSizedImage($alt = null, $class = null, $id = null, $imgobj = null, $hd = true) {
 	global $_zp_current_image;
@@ -696,11 +696,11 @@ function getHDImageThumb($imgobj = null, $hd = true) {
 /**
  * Standard thumb as set on the options
  *
- * @param bool $hd Set to true if the HiDPI counterpart should be generated
  * @param string $alt Alt text
  * @param string $class optional class tag
  * @param string $id optional id tag
  * @param string $imgobj Image object 
+ * @param bool $hd Set to true if the HiDPI counterpart should be generated
  */
 function printHDImageThumb($alt = null, $class = null, $id = null, $imgobj = null, $hd = true) {
   $img = getHDImageThumb($imgobj, $hd);
@@ -713,11 +713,11 @@ function printHDImageThumb($alt = null, $class = null, $id = null, $imgobj = nul
  * If the album is protected for the viewer and the lock image option is set it prints this lock image
  * plainly without any sizes or HiDPI support
  *
- * @param bool $hd Set to true if the HiDPI counterpart should be generated
  * @param string $alt Alt text
  * @param string $class optional class tag
  * @param string $id optional id tag
  * @param string $albobj Album object optionally
+ * @param bool $hd Set to true if the HiDPI counterpart should be generated
  */
 function printHDAlbumThumbImage($alt = null, $class = null, $id = null, $albobj = null, $hd = true) {
 	global $_zp_current_album;
@@ -760,6 +760,8 @@ function printHDAlbumThumbImage($alt = null, $class = null, $id = null, $albobj 
  * @param int $cropy crop part y axis
  * @param string $class css class
  * @param string $id css id
+ * @param string $albobj Album object optionally
+ * @param bool $hd Set to true if the HiDPI counterpart should be generated
  *
  * @return string
  */

--- a/zp_picturefill.php
+++ b/zp_picturefill.php
@@ -702,7 +702,7 @@ function getHDImageThumb($imgobj = null, $hd = true) {
  * @param string $id optional id tag
  * @param string $imgobj Image object 
  */
-function printHDImageThumb($hd = true, $alt = null, $class = null, $id = null, $imgobj = null) {
+function printHDImageThumb($alt = null, $class = null, $id = null, $imgobj = null, $hd = true) {
   $img = getHDImageThumb($imgobj, $hd);
   printHDSrcsetImage($img['img_sd'], $img['img_hd'], $class, $id, $alt, 'standard_image_thumb');
   //printResponsiveImage($img['img_sd'], $img['img_hd'], null, null, null, null, $class, $id, $alt, 'standard_image_thumb');


### PR DESCRIPTION
Hi there,
Just a little contribution as I started to use this great plugin today. IMO, it should be integrated to ZP core and activated by default. It turns on the magic of mobile and retina screens.
I think this could be great to be as close as possible to the initial methods (without the `HD` part) to facilitate theme migration.
Have a nice day.